### PR TITLE
Use helm to perform lsp-execute-code-action

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,3 +10,4 @@ which provides as you type completion.
 * Commands
   - ~helm-lsp-workspace-symbol~ - workspace symbols for the current workspace
   - ~helm-lsp-global-workspace-symbol~ - workspace symbols from all of the active workspaces.
+  - ~helm-lsp-code-actions~ - helm interface to lsp-execute-code-action.

--- a/helm-lsp.el
+++ b/helm-lsp.el
@@ -129,5 +129,28 @@ When called with prefix ARG the default selection will be symbol at point."
                               "Global workspace symbols"
                               (when arg (thing-at-point 'symbol))))
 
+;;;###autoload
+(defun helm-lsp-code-actions()
+  "Show lsp code actions using helm."
+  (interactive)
+  (let ((actions (lsp-code-actions-at-point)))
+    (cond
+     ((seq-empty-p actions) (signal 'lsp-no-code-actions nil))
+     ((and (eq (seq-length actions) 1) lsp-auto-execute-action)
+      (lsp-execute-code-action (lsp-seq-first actions)))
+     (t (helm :sources
+              (helm-build-sync-source "Code Actions"
+                :candidates actions
+                :candidate-transformer
+                (lambda (candidates)
+                  (-map
+                   (-lambda ((candidate &as
+                                        &hash "title" title))
+                     (list title
+                           :data candidate))
+                   candidates))
+                :action '(("Execute code action" . (lambda(candidate)
+                                                     (lsp-execute-code-action (plist-get candidate :data)))))))))))
+
 (provide 'helm-lsp)
 ;;; helm-lsp.el ends here


### PR DESCRIPTION
I find it far nicer to use code actions through helm rather than the prompt from lsp-execute-code-action, so I wrote this, thought it might be useful for others too. 
