### PR TITLE
Fix for diagnostics sort function data format

### DIFF
--- a/helm-lsp.el
+++ b/helm-lsp.el
@@ -281,10 +281,8 @@ With a prefix ARG invalidates the cache first."
                        (propertize file 'face 'lsp-details-face)
                        (propertize (format ":%s:%s" line character) 'face 'lsp-details-face))
                       full-path start))))
-     (-sort (-lambda ((full-path-1 _ (&Diagnostic :range
-                                                  (&Range :start (&Position :line l1 :character c1))))
-                      (full-path-2 _ (&Diagnostic :range
-                                                  (&Range :start (&Position :line l2 :character c2)))))
+     (-sort (-lambda ((_ full-path-1 (&Position :line l1 :character c1))
+                      (_ full-path-2 (&Position :line l2 :character c2)))
               (if (string= full-path-1 full-path-2)
                   (if (= l1 l2) (< c1 c2) (< l1 l2))
                 (string< full-path-1 full-path-2)))))))


### PR DESCRIPTION
Predicate for diagnostics  sort function was fixed  so that parameters
format corresponds to the data format in the sorted list.